### PR TITLE
Feature/break into components and pages

### DIFF
--- a/apps/viewer-demo-v2/package.json
+++ b/apps/viewer-demo-v2/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@craco/craco": "^6.2.0",
-    "@lunit/osd-react-renderer": "^1.0.1",
+    "@lunit/osd-react-renderer": "^1.1.0",
     "@material-ui/core": "^4.12.3",
     "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.60",
@@ -21,11 +21,13 @@
     "openseadragon": "^2.4.2",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "react-router-dom": "^5.3.0",
+    "react-router-dom": "^5.3.4",
     "react-scripts": "4.0.3",
     "styled-components": "^5.3.1",
     "typescript": "^4.1.2",
-    "web-vitals": "^1.0.1"
+    "web-vitals": "^1.0.1",
+    "jotai": "^2.5.0",
+    "react-error-boundary": "4.0.11"
   },
   "scripts": {
     "start": "craco start",
@@ -54,7 +56,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.178",
     "@types/offscreencanvas": "^2019.7.0",
-    "@types/react-router-dom": "^5.3.1",
+    "@types/react-router-dom": "^5.3.3",
     "@types/styled-components": "^5.1.13"
   }
 }

--- a/apps/viewer-demo-v2/package.json
+++ b/apps/viewer-demo-v2/package.json
@@ -26,8 +26,7 @@
     "styled-components": "^5.3.1",
     "typescript": "^4.1.2",
     "web-vitals": "^1.0.1",
-    "jotai": "^2.5.0",
-    "react-error-boundary": "4.0.11"
+    "jotai": "^2.5.0"
   },
   "scripts": {
     "start": "craco start",

--- a/apps/viewer-demo-v2/src/App.tsx
+++ b/apps/viewer-demo-v2/src/App.tsx
@@ -1,25 +1,14 @@
-import OSDViewer, {
-  ScalebarLocation,
-  ViewportProps,
-  TooltipOverlayProps,
-  CanvasOverlayProps,
-  MouseTrackerProps,
-  OSDViewerRef,
-} from '@lunit/osd-react-renderer'
-import OpenSeadragon from 'openseadragon'
 import { BrowserRouter, Switch, Route, NavLink } from 'react-router-dom'
-import { useCallback, useRef, useState } from 'react'
 import styled from 'styled-components'
-import ZoomController, { ZoomControllerProps } from './ZoomController'
-import useWebGL from './hooks/useWebGL'
+import { ErrorBoundary } from 'react-error-boundary'
 
-import useSVG from './hooks/useSVG'
-
-const tiledImageSource = {
-  url: 'https://io.api.scope.lunit.io/slides/dzi/metadata/?file=01d0f99c-b4fa-41c1-9059-4c2ee5d4cdf1%2F97e1f14b-d883-409a-83c6-afa97513c146%2FBladder_cancer_01.svs',
-  tileUrlBase:
-    'https://io.api.scope.lunit.io/slides/images/dzi/01d0f99c-b4fa-41c1-9059-4c2ee5d4cdf1%2F97e1f14b-d883-409a-83c6-afa97513c146%2FBladder_cancer_01.svs',
-}
+import TestPage from './pages/Test'
+import SvgPage from './pages/Svg'
+import WebglPage from './pages/Webgl'
+import TestCustom from './pages/TestCustom'
+import Home from './pages'
+import NoOverlay from './pages/NoOverlay'
+import { atom } from 'jotai'
 
 const Container = styled.div`
   width: 100%;
@@ -51,64 +40,6 @@ const Links = styled.div`
   }
 `
 
-const DEFAULT_CONTROLLER_MIN_ZOOM: number = 0.3125
-const DEFAULT_CONTROLLER_MAX_ZOOM: number = 160
-const DEMO_MPP = 0.263175
-const MICRONS_PER_METER = 1e6
-const RADIUS_UM = 281.34
-const VIEWER_OPTIONS = {
-  imageLoaderLimit: 8,
-  smoothTileEdgesMinZoom: Infinity,
-  showNavigator: true,
-  showNavigationControl: false,
-  timeout: 60000,
-  navigatorAutoResize: false,
-  preserveImageSizeOnResize: true,
-  showRotationControl: true,
-  zoomPerScroll: 1.3,
-  animationTime: 0.3,
-  gestureSettingsMouse: {
-    clickToZoom: false,
-    dblClickToZoom: false,
-  },
-  gestureSettingsTouch: {
-    flickEnabled: false,
-    clickToZoom: false,
-    dblClickToZoom: false,
-  },
-}
-const WHEEL_BUTTON = 1
-
-const onCanvasOverlayRedraw: NonNullable<CanvasOverlayProps['onRedraw']> = (
-  canvas: HTMLCanvasElement
-) => {
-  const ctx = canvas.getContext('2d')
-  if (ctx) {
-    ctx.fillStyle = '#000'
-    ctx.fillRect(50, 50, 5000, 5000)
-  }
-}
-
-const onTooltipOverlayRedraw: NonNullable<TooltipOverlayProps['onRedraw']> = ({
-  tooltipCoord,
-  overlayCanvasEl,
-  viewer,
-}) => {
-  const ctx = overlayCanvasEl.getContext('2d')
-  if (ctx && tooltipCoord) {
-    const radiusPx = RADIUS_UM / DEMO_MPP
-    const sizeRect = new OpenSeadragon.Rect(0, 0, 2, 2)
-    const lineWidth = viewer.viewport.viewportToImageRectangle(
-      viewer.viewport.viewerElementToViewportRectangle(sizeRect)
-    ).width
-    ctx.lineWidth = lineWidth
-    ctx.beginPath()
-    ctx.arc(tooltipCoord.x, tooltipCoord.y, radiusPx, 0, 2 * Math.PI)
-    ctx.closePath()
-    ctx.stroke()
-  }
-}
-
 // function makeTiledCoords(
 //   tiles: number,
 //   coordCount: number,
@@ -139,163 +70,10 @@ const onTooltipOverlayRedraw: NonNullable<TooltipOverlayProps['onRedraw']> = ({
 //   return out
 // }
 
-let timer: ReturnType<typeof setTimeout>
+export const scaleFactorAtom = atom(1)
+export const viewportZoomAtom = atom(1)
 
-function App() {
-  const [viewportZoom, setViewportZoom] = useState<number>(1)
-  const [refPoint, setRefPoint] = useState<OpenSeadragon.Point>()
-  const [rotation, setRotation] = useState<number>(0)
-  const [scaleFactor, setScaleFactor] = useState<number>(1)
-  const [rectSize, setRectSize] = useState<[number, number]>([5000, 5000])
-
-  const canvasOverlayRef = useRef(null)
-  const webGLOverlayRef = useRef(null)
-  const osdViewerRef = useRef<OSDViewerRef>(null)
-  const lastPoint = useRef<OpenSeadragon.Point | null>(null)
-  const prevDelta = useRef<OpenSeadragon.Point | null>(null)
-  const prevTime = useRef<number>(-1)
-
-  const { onWebGLOverlayRedraw } = useWebGL()
-  const { setSVGSubVisibility, setSVGAllVisible } = useSVG()
-
-  const cancelPanning = useCallback(() => {
-    lastPoint.current = null
-    prevDelta.current = null
-    prevTime.current = -1
-  }, [])
-
-  const refreshScaleFactor = useCallback(() => {
-    const viewer = osdViewerRef.current?.viewer
-    if (!viewer) {
-      return
-    }
-    const imageWidth = viewer.world.getItemAt(0).getContentSize().x
-    const microscopeWidth1x = ((imageWidth * DEMO_MPP) / 25400) * 96 * 10
-    const viewportWidth = viewer.viewport.getContainerSize().x
-    setScaleFactor(microscopeWidth1x / viewportWidth)
-  }, [])
-
-  const handleViewportOpen = useCallback<
-    NonNullable<ViewportProps['onOpen']>
-  >(() => {
-    refreshScaleFactor()
-  }, [refreshScaleFactor])
-
-  const handleViewportResize = useCallback<
-    NonNullable<ViewportProps['onResize']>
-  >(() => {
-    refreshScaleFactor()
-  }, [refreshScaleFactor])
-
-  const handleViewportRotate = useCallback<
-    NonNullable<ViewportProps['onRotate']>
-  >(
-    ({ eventSource: viewer, degrees }) => {
-      if (viewer == null || degrees == null) {
-        return
-      }
-      refreshScaleFactor()
-      setRotation(degrees)
-    },
-    [refreshScaleFactor]
-  )
-
-  const handleViewportZoom = useCallback<NonNullable<ViewportProps['onZoom']>>(
-    ({ eventSource: viewer, zoom, refPoint }) => {
-      if (viewer == null || zoom == null) {
-        return
-      }
-      setViewportZoom(zoom)
-      setRefPoint(refPoint || undefined)
-    },
-    []
-  )
-
-  const handleControllerZoom = useCallback<
-    NonNullable<ZoomControllerProps['onZoom']>
-  >(
-    zoom => {
-      setViewportZoom(zoom * scaleFactor)
-    },
-    [scaleFactor]
-  )
-
-  const handleUpdatedCanvasOverlayRedraw = useCallback<
-    NonNullable<CanvasOverlayProps['onRedraw']>
-  >(
-    (canvas: HTMLCanvasElement, viewer: OpenSeadragon.Viewer) => {
-      const ctx = canvas.getContext('2d')
-      if (ctx) {
-        ctx.fillStyle = 'rgba(0,0,0,0.3)'
-        ctx.fillRect(50, 50, rectSize[0], rectSize[1])
-      }
-      if (viewer.world && viewer.world.getItemAt(0)) {
-        const imgSize = viewer.world.getItemAt(0).getContentSize()
-        clearTimeout(timer)
-        timer = setTimeout(() => {
-          setRectSize([Math.random() * imgSize.x, Math.random() * imgSize.y])
-        }, 5000)
-      }
-    },
-    [rectSize]
-  )
-
-  const handleMouseTrackerLeave = useCallback<
-    NonNullable<MouseTrackerProps['onLeave']>
-  >(() => {
-    // temporary fix about malfunction(?) of mouseup and onNonPrimaryRelease event
-    cancelPanning?.()
-  }, [cancelPanning])
-
-  const handleMouseTrackerNonPrimaryPress = useCallback<
-    NonNullable<MouseTrackerProps['onNonPrimaryPress']>
-  >(event => {
-    if (event.button === WHEEL_BUTTON) {
-      lastPoint.current = event.position?.clone() || null
-      prevDelta.current = new OpenSeadragon.Point(0, 0)
-      prevTime.current = 0
-    }
-  }, [])
-
-  const handleMouseTrackerNonPrimaryRelease = useCallback<
-    NonNullable<MouseTrackerProps['onNonPrimaryRelease']>
-  >(
-    event => {
-      if (event.button === WHEEL_BUTTON) {
-        cancelPanning()
-      }
-    },
-    [cancelPanning]
-  )
-
-  const handleMouseTrackerMove = useCallback<
-    NonNullable<MouseTrackerProps['onMove']>
-  >(event => {
-    const viewer = osdViewerRef.current?.viewer
-    const throttle = 150
-    if (viewer && viewer.viewport) {
-      if (lastPoint.current && event.position) {
-        const deltaPixels = lastPoint.current.minus(event.position)
-        const deltaPoints = viewer.viewport.deltaPointsFromPixels(deltaPixels)
-        lastPoint.current = event.position.clone()
-        if (!throttle || throttle < 0) {
-          viewer.viewport.panBy(deltaPoints)
-        } else if (prevDelta.current) {
-          const newTimeDelta = Date.now() - prevTime.current
-          const newDelta = prevDelta.current.plus(deltaPoints)
-          if (newTimeDelta > throttle) {
-            viewer.viewport.panBy(newDelta)
-            prevDelta.current = new OpenSeadragon.Point(0, 0)
-            prevTime.current = 0
-          } else {
-            prevDelta.current = newDelta
-            prevTime.current = newTimeDelta
-          }
-        }
-      }
-    }
-  }, [])
-
+function App(this: any) {
   return (
     <BrowserRouter>
       <Container>
@@ -304,180 +82,30 @@ function App() {
           <NavLink to="/test-custom">CUSTOM IMG URL</NavLink>
           <NavLink to="/no-overlay">NO OVERLAY</NavLink>
           <NavLink to="/test">TEST</NavLink>
-          <NavLink to="/destroy">TEST DESTROY</NavLink>
           <NavLink to="/webgl">TEST WEBGL</NavLink>
           <NavLink to="/svg">SVG</NavLink>
         </Links>
-        <Route exact path="/svg">
-          <div style={{ display: 'flex', flexDirection: 'column' }}>
-            <button onClick={setSVGAllVisible}>svg visible</button>
-            <button onClick={() => setSVGSubVisibility(0)}>svg sub 1</button>
-            <button onClick={() => setSVGSubVisibility(1)}>svg sub 2</button>
-            <button onClick={() => setSVGSubVisibility(2)}>svg sub 3</button>
-          </div>
-        </Route>
         <Switch>
           <OSDContainer>
-            <Route exact path="/test">
-              <OSDViewer options={VIEWER_OPTIONS} ref={osdViewerRef}>
-                <viewport
-                  zoom={viewportZoom}
-                  refPoint={refPoint}
-                  rotation={rotation}
-                  onOpen={handleViewportOpen}
-                  onResize={handleViewportResize}
-                  onRotate={handleViewportRotate}
-                  onZoom={handleViewportZoom}
-                  maxZoomLevel={DEFAULT_CONTROLLER_MAX_ZOOM * scaleFactor}
-                  minZoomLevel={DEFAULT_CONTROLLER_MIN_ZOOM * scaleFactor}
-                />
-                <tiledImage {...tiledImageSource} />
-                <scalebar
-                  pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
-                  xOffset={10}
-                  yOffset={30}
-                  barThickness={3}
-                  color="#443aff"
-                  fontColor="#53646d"
-                  backgroundColor={'rgba(255,255,255,0.5)'}
-                  location={ScalebarLocation.BOTTOM_RIGHT}
-                />
-                <canvasOverlay
-                  ref={canvasOverlayRef}
-                  onRedraw={handleUpdatedCanvasOverlayRedraw}
-                />
-              </OSDViewer>
-            </Route>
-            <Route exact path="/webgl">
-              <OSDViewer
-                options={VIEWER_OPTIONS}
-                ref={osdViewerRef}
-                style={{ width: '100%', height: '100%' }}
-              >
-                <viewport
-                  zoom={viewportZoom}
-                  refPoint={refPoint}
-                  rotation={rotation}
-                  onOpen={handleViewportOpen}
-                  onResize={handleViewportResize}
-                  onRotate={handleViewportRotate}
-                  onZoom={handleViewportZoom}
-                  maxZoomLevel={DEFAULT_CONTROLLER_MAX_ZOOM * scaleFactor}
-                  minZoomLevel={DEFAULT_CONTROLLER_MIN_ZOOM * scaleFactor}
-                />
-                <tiledImage {...tiledImageSource} />
-                <scalebar
-                  pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
-                  xOffset={10}
-                  yOffset={30}
-                  barThickness={3}
-                  color="#443aff"
-                  fontColor="#53646d"
-                  backgroundColor={'rgba(255,255,255,0.5)'}
-                  location={ScalebarLocation.BOTTOM_RIGHT}
-                />
-                <webGLOverlay
-                  ref={webGLOverlayRef}
-                  onRedraw={onWebGLOverlayRedraw}
-                />
-              </OSDViewer>
-            </Route>
-            <Route exact path="/svg">
-              <OSDViewer
-                options={VIEWER_OPTIONS}
-                ref={osdViewerRef}
-                style={{ width: '100%', height: '100%' }}
-              >
-                <viewport
-                  zoom={viewportZoom}
-                  refPoint={refPoint}
-                  rotation={rotation}
-                  onOpen={handleViewportOpen}
-                  onResize={handleViewportResize}
-                  onRotate={handleViewportRotate}
-                  onZoom={handleViewportZoom}
-                  maxZoomLevel={DEFAULT_CONTROLLER_MAX_ZOOM * scaleFactor}
-                  minZoomLevel={DEFAULT_CONTROLLER_MIN_ZOOM * scaleFactor}
-                />
-                <tiledImage {...tiledImageSource} />
-                <svgOverlay />
-                <mouseTracker
-                  onLeave={handleMouseTrackerLeave}
-                  onNonPrimaryPress={handleMouseTrackerNonPrimaryPress}
-                  onNonPrimaryRelease={handleMouseTrackerNonPrimaryRelease}
-                  onMove={handleMouseTrackerMove}
-                />
-                <scalebar
-                  pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
-                  xOffset={10}
-                  yOffset={30}
-                  barThickness={3}
-                  color="#443aff"
-                  fontColor="#53646d"
-                  backgroundColor={'rgba(255,255,255,0.5)'}
-                  location={ScalebarLocation.BOTTOM_RIGHT}
-                />
-              </OSDViewer>
-            </Route>
             <Route exact path="/test-custom">
-              <OSDViewer options={VIEWER_OPTIONS} ref={osdViewerRef}>
-                <tiledImage
-                  url="https://pdl1.api.dev.scope.lunit.io/slides/dzi/metadata?file=mrxs_test/SIZE_TEST_2.mrxs"
-                  tileUrlBase="https://pdl1.api.dev.scope.lunit.io/slides/images/dzi/mrxs_test/SIZE_TEST_2.mrxs"
-                />
-              </OSDViewer>
-            </Route>
-            <Route exact path="/">
-              <OSDViewer
-                options={VIEWER_OPTIONS}
-                ref={osdViewerRef}
-                style={{ width: '100%', height: '100%' }}
-              >
-                <viewport
-                  zoom={viewportZoom}
-                  refPoint={refPoint}
-                  rotation={rotation}
-                  onOpen={handleViewportOpen}
-                  onResize={handleViewportResize}
-                  onRotate={handleViewportRotate}
-                  onZoom={handleViewportZoom}
-                  maxZoomLevel={DEFAULT_CONTROLLER_MAX_ZOOM * scaleFactor}
-                  minZoomLevel={DEFAULT_CONTROLLER_MIN_ZOOM * scaleFactor}
-                />
-                <tiledImage {...tiledImageSource} />
-                <scalebar
-                  pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
-                  xOffset={10}
-                  yOffset={30}
-                  barThickness={3}
-                  color="#443aff"
-                  fontColor="#53646d"
-                  backgroundColor={'rgba(255,255,255,0.5)'}
-                  location={ScalebarLocation.BOTTOM_RIGHT}
-                />
-                <canvasOverlay
-                  ref={canvasOverlayRef}
-                  onRedraw={onCanvasOverlayRedraw}
-                />
-                <tooltipOverlay onRedraw={onTooltipOverlayRedraw} />
-                <mouseTracker
-                  onLeave={handleMouseTrackerLeave}
-                  onNonPrimaryPress={handleMouseTrackerNonPrimaryPress}
-                  onNonPrimaryRelease={handleMouseTrackerNonPrimaryRelease}
-                  onMove={handleMouseTrackerMove}
-                />
-              </OSDViewer>
-              <ZoomController
-                zoom={viewportZoom / scaleFactor}
-                maxZoomLevel={DEFAULT_CONTROLLER_MAX_ZOOM}
-                minZoomLevel={DEFAULT_CONTROLLER_MIN_ZOOM}
-                onZoom={handleControllerZoom}
-              />
+              <TestCustom />
             </Route>
             <Route exact path="/no-overlay">
-              <OSDViewer options={VIEWER_OPTIONS} ref={osdViewerRef}>
-                <tiledImage {...tiledImageSource} />
-              </OSDViewer>
+              <NoOverlay />
+            </Route>
+            <Route exact path="/test">
+              <TestPage />
+            </Route>
+            <Route exact path="/webgl">
+              <WebglPage />
+            </Route>
+            <Route exact path="/svg">
+              <ErrorBoundary fallback={<div>error boundary test</div>}>
+                <SvgPage />
+              </ErrorBoundary>
+            </Route>
+            <Route exact path="/">
+              <Home />
             </Route>
           </OSDContainer>
         </Switch>

--- a/apps/viewer-demo-v2/src/App.tsx
+++ b/apps/viewer-demo-v2/src/App.tsx
@@ -1,6 +1,5 @@
 import { BrowserRouter, Switch, Route, NavLink } from 'react-router-dom'
 import styled from 'styled-components'
-import { ErrorBoundary } from 'react-error-boundary'
 
 import TestPage from './pages/Test'
 import SvgPage from './pages/Svg'
@@ -73,7 +72,7 @@ const Links = styled.div`
 export const scaleFactorAtom = atom(1)
 export const viewportZoomAtom = atom(1)
 
-function App(this: any) {
+function App() {
   return (
     <BrowserRouter>
       <Container>
@@ -100,9 +99,7 @@ function App(this: any) {
               <WebglPage />
             </Route>
             <Route exact path="/svg">
-              <ErrorBoundary fallback={<div>error boundary test</div>}>
-                <SvgPage />
-              </ErrorBoundary>
+              <SvgPage />
             </Route>
             <Route exact path="/">
               <Home />

--- a/apps/viewer-demo-v2/src/components/CanvasOverlay.tsx
+++ b/apps/viewer-demo-v2/src/components/CanvasOverlay.tsx
@@ -1,0 +1,11 @@
+import { useRef } from 'react'
+
+export default function CanvasOverlay({
+  redrawFn,
+}: {
+  redrawFn: (overlayCanvasEl: HTMLCanvasElement, viewer: any) => void
+}) {
+  const canvasOverlayRef = useRef(null)
+
+  return <canvasOverlay ref={canvasOverlayRef} onRedraw={redrawFn} />
+}

--- a/apps/viewer-demo-v2/src/components/MouseTracker.tsx
+++ b/apps/viewer-demo-v2/src/components/MouseTracker.tsx
@@ -1,0 +1,88 @@
+import { MouseTrackerProps, OSDViewerRef } from '@lunit/osd-react-renderer'
+import OpenSeadragon from 'openseadragon'
+import { RefObject, useCallback, useRef } from 'react'
+import { WHEEL_BUTTON } from '../const'
+
+export default function MouseTracker({
+  osdViewerRef,
+}: {
+  osdViewerRef: RefObject<OSDViewerRef>
+}) {
+  const lastPoint = useRef<OpenSeadragon.Point | null>(null)
+  const prevDelta = useRef<OpenSeadragon.Point | null>(null)
+  const prevTime = useRef<number>(-1)
+
+  const cancelPanning = useCallback(() => {
+    lastPoint.current = null
+    prevDelta.current = null
+    prevTime.current = -1
+  }, [])
+
+  const handleMouseTrackerLeave = useCallback<
+    NonNullable<MouseTrackerProps['onLeave']>
+  >(() => {
+    // temporary fix about malfunction(?) of mouseup and onNonPrimaryRelease event
+    cancelPanning?.()
+  }, [cancelPanning])
+
+  const handleMouseTrackerNonPrimaryPress = useCallback<
+    NonNullable<MouseTrackerProps['onNonPrimaryPress']>
+  >(event => {
+    if (event.button === WHEEL_BUTTON) {
+      lastPoint.current = event.position?.clone() || null
+      prevDelta.current = new OpenSeadragon.Point(0, 0)
+      prevTime.current = 0
+    }
+  }, [])
+
+  const handleMouseTrackerNonPrimaryRelease = useCallback<
+    NonNullable<MouseTrackerProps['onNonPrimaryRelease']>
+  >(
+    event => {
+      if (event.button === WHEEL_BUTTON) {
+        cancelPanning()
+      }
+    },
+    [cancelPanning]
+  )
+
+  const handleMouseTrackerMove = useCallback<
+    NonNullable<MouseTrackerProps['onMove']>
+  >(
+    event => {
+      const viewer = osdViewerRef.current?.viewer
+      const throttle = 150
+      if (viewer && viewer.viewport) {
+        if (lastPoint.current && event.position) {
+          const deltaPixels = lastPoint.current.minus(event.position)
+          const deltaPoints = viewer.viewport.deltaPointsFromPixels(deltaPixels)
+          lastPoint.current = event.position.clone()
+          if (!throttle || throttle < 0) {
+            viewer.viewport.panBy(deltaPoints)
+          } else if (prevDelta.current) {
+            const newTimeDelta = Date.now() - prevTime.current
+            const newDelta = prevDelta.current.plus(deltaPoints)
+            if (newTimeDelta > throttle) {
+              viewer.viewport.panBy(newDelta)
+              prevDelta.current = new OpenSeadragon.Point(0, 0)
+              prevTime.current = 0
+            } else {
+              prevDelta.current = newDelta
+              prevTime.current = newTimeDelta
+            }
+          }
+        }
+      }
+    },
+    [osdViewerRef]
+  )
+
+  return (
+    <mouseTracker
+      onLeave={handleMouseTrackerLeave}
+      onNonPrimaryPress={handleMouseTrackerNonPrimaryPress}
+      onNonPrimaryRelease={handleMouseTrackerNonPrimaryRelease}
+      onMove={handleMouseTrackerMove}
+    />
+  )
+}

--- a/apps/viewer-demo-v2/src/components/Viewport.tsx
+++ b/apps/viewer-demo-v2/src/components/Viewport.tsx
@@ -1,0 +1,84 @@
+import { ViewportProps } from 'packages/renderer/src/types'
+import { RefObject, useCallback, useState } from 'react'
+import { OSDViewerRef } from '@lunit/osd-react-renderer'
+import {
+  DEMO_MPP,
+  DEFAULT_CONTROLLER_MAX_ZOOM,
+  DEFAULT_CONTROLLER_MIN_ZOOM,
+} from '../const'
+import { scaleFactorAtom, viewportZoomAtom } from '../App'
+import { useAtom } from 'jotai'
+
+export default function Viewport({
+  osdViewerRef,
+}: {
+  osdViewerRef: RefObject<OSDViewerRef>
+}) {
+  const [rotation, setRotation] = useState<number>(0)
+  const [refPoint, setRefPoint] = useState<OpenSeadragon.Point>()
+  const [scaleFactor, setScaleFactor] = useAtom(scaleFactorAtom)
+  const [viewportZoom, setViewportZoom] = useAtom(viewportZoomAtom)
+
+  const handleViewportZoom = useCallback<NonNullable<ViewportProps['onZoom']>>(
+    ({ eventSource: viewer, zoom, refPoint }) => {
+      if (viewer == null || zoom == null) {
+        return
+      }
+      setViewportZoom(zoom)
+      setRefPoint(refPoint || undefined)
+    },
+    [setViewportZoom]
+  )
+
+  const refreshScaleFactor = useCallback(() => {
+    const viewer = osdViewerRef.current?.viewer
+    if (!viewer || !viewer.world.getItemAt(0)) {
+      return
+    }
+    const imageWidth = viewer.world.getItemAt(0).getContentSize().x
+    const microscopeWidth1x = ((imageWidth * DEMO_MPP) / 25400) * 96 * 10
+    const viewportWidth = viewer.viewport.getContainerSize().x
+    setScaleFactor(microscopeWidth1x / viewportWidth)
+  }, [osdViewerRef, setScaleFactor])
+
+  const handleViewportOpen = useCallback<
+    NonNullable<ViewportProps['onOpen']>
+  >(() => {
+    refreshScaleFactor()
+  }, [refreshScaleFactor])
+
+  const handleViewportResize = useCallback<
+    NonNullable<ViewportProps['onResize']>
+  >(() => {
+    refreshScaleFactor()
+  }, [refreshScaleFactor])
+
+  const handleViewportRotate = useCallback<
+    NonNullable<ViewportProps['onRotate']>
+  >(
+    ({ eventSource: viewer, degrees }) => {
+      if (viewer == null || degrees == null) {
+        return
+      }
+      refreshScaleFactor()
+      setRotation(degrees)
+    },
+    [refreshScaleFactor]
+  )
+
+  return (
+    <>
+      <viewport
+        zoom={viewportZoom}
+        refPoint={refPoint}
+        rotation={rotation}
+        onOpen={handleViewportOpen}
+        onResize={handleViewportResize}
+        onRotate={handleViewportRotate}
+        onZoom={handleViewportZoom}
+        maxZoomLevel={DEFAULT_CONTROLLER_MAX_ZOOM * scaleFactor}
+        minZoomLevel={DEFAULT_CONTROLLER_MIN_ZOOM * scaleFactor}
+      />
+    </>
+  )
+}

--- a/apps/viewer-demo-v2/src/const.ts
+++ b/apps/viewer-demo-v2/src/const.ts
@@ -1,0 +1,33 @@
+export const DEFAULT_CONTROLLER_MIN_ZOOM: number = 0.3125
+export const DEFAULT_CONTROLLER_MAX_ZOOM: number = 160
+export const DEMO_MPP = 0.263175
+export const MICRONS_PER_METER = 1e6
+export const RADIUS_UM = 281.34
+export const WHEEL_BUTTON = 1
+export const VIEWER_OPTIONS = {
+  imageLoaderLimit: 8,
+  smoothTileEdgesMinZoom: Infinity,
+  showNavigator: true,
+  showNavigationControl: false,
+  timeout: 60000,
+  navigatorAutoResize: false,
+  preserveImageSizeOnResize: true,
+  showRotationControl: true,
+  zoomPerScroll: 1.3,
+  animationTime: 0.3,
+  gestureSettingsMouse: {
+    clickToZoom: false,
+    dblClickToZoom: false,
+  },
+  gestureSettingsTouch: {
+    flickEnabled: false,
+    clickToZoom: false,
+    dblClickToZoom: false,
+  },
+}
+
+export const tiledImageSource = {
+  url: 'https://io.api.scope.lunit.io/slides/dzi/metadata/?file=01d0f99c-b4fa-41c1-9059-4c2ee5d4cdf1%2F97e1f14b-d883-409a-83c6-afa97513c146%2FBladder_cancer_01.svs',
+  tileUrlBase:
+    'https://io.api.scope.lunit.io/slides/images/dzi/01d0f99c-b4fa-41c1-9059-4c2ee5d4cdf1%2F97e1f14b-d883-409a-83c6-afa97513c146%2FBladder_cancer_01.svs',
+}

--- a/apps/viewer-demo-v2/src/hooks/useSVG/index.ts
+++ b/apps/viewer-demo-v2/src/hooks/useSVG/index.ts
@@ -1,5 +1,8 @@
 import { useEffect, useRef, useState } from 'react'
-import { SVG_NAMESPACE, SVG_ROOT_ID } from '@lunit/osd-react-renderer'
+import {
+  SVG_NAMESPACE,
+  SVG_ROOT_ID,
+} from '../../../../../packages/renderer/src'
 import data from '../../gridData'
 
 const offset = {

--- a/apps/viewer-demo-v2/src/pages/NoOverlay.tsx
+++ b/apps/viewer-demo-v2/src/pages/NoOverlay.tsx
@@ -1,0 +1,13 @@
+import OSDViewer, { OSDViewerRef } from '@lunit/osd-react-renderer'
+import { VIEWER_OPTIONS, tiledImageSource } from '../const'
+import { useRef } from 'react'
+
+export default function NoOverlay() {
+  const osdViewerRef = useRef<OSDViewerRef>(null)
+
+  return (
+    <OSDViewer options={VIEWER_OPTIONS} ref={osdViewerRef}>
+      <tiledImage {...tiledImageSource} />
+    </OSDViewer>
+  )
+}

--- a/apps/viewer-demo-v2/src/pages/Svg.tsx
+++ b/apps/viewer-demo-v2/src/pages/Svg.tsx
@@ -20,7 +20,13 @@ export default function SvgPage() {
 
   return (
     <>
-      <div style={{ display: 'flex', flexDirection: 'column' }}>
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          width: 'max-content',
+        }}
+      >
         <button onClick={setSVGAllVisible}>svg visible</button>
         <button onClick={() => setSVGSubVisibility(0)}>svg sub 1</button>
         <button onClick={() => setSVGSubVisibility(1)}>svg sub 2</button>

--- a/apps/viewer-demo-v2/src/pages/Svg.tsx
+++ b/apps/viewer-demo-v2/src/pages/Svg.tsx
@@ -1,0 +1,52 @@
+import OSDViewer, {
+  OSDViewerRef,
+  ScalebarLocation,
+} from '@lunit/osd-react-renderer'
+import MouseTracker from '../components/MouseTracker'
+import Viewport from '../components/Viewport'
+import {
+  VIEWER_OPTIONS,
+  tiledImageSource,
+  MICRONS_PER_METER,
+  DEMO_MPP,
+} from '../const'
+import useSVG from '../hooks/useSVG'
+import { useRef } from 'react'
+
+export default function SvgPage() {
+  const osdViewerRef = useRef<OSDViewerRef>(null)
+
+  const { setSVGSubVisibility, setSVGAllVisible } = useSVG()
+
+  return (
+    <>
+      <div style={{ display: 'flex', flexDirection: 'column' }}>
+        <button onClick={setSVGAllVisible}>svg visible</button>
+        <button onClick={() => setSVGSubVisibility(0)}>svg sub 1</button>
+        <button onClick={() => setSVGSubVisibility(1)}>svg sub 2</button>
+        <button onClick={() => setSVGSubVisibility(2)}>svg sub 3</button>
+      </div>
+      <OSDViewer
+        options={VIEWER_OPTIONS}
+        ref={osdViewerRef}
+        style={{ width: '100%', height: '100%' }}
+      >
+        <Viewport osdViewerRef={osdViewerRef} />
+
+        <tiledImage {...tiledImageSource} />
+        <svgOverlay />
+        <MouseTracker osdViewerRef={osdViewerRef} />
+        <scalebar
+          pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
+          xOffset={10}
+          yOffset={30}
+          barThickness={3}
+          color="#443aff"
+          fontColor="#53646d"
+          backgroundColor={'rgba(255,255,255,0.5)'}
+          location={ScalebarLocation.BOTTOM_RIGHT}
+        />
+      </OSDViewer>
+    </>
+  )
+}

--- a/apps/viewer-demo-v2/src/pages/Test.tsx
+++ b/apps/viewer-demo-v2/src/pages/Test.tsx
@@ -1,0 +1,62 @@
+import OSDViewer, {
+  CanvasOverlayProps,
+  OSDViewerRef,
+  ScalebarLocation,
+} from '@lunit/osd-react-renderer'
+import Viewport from '../components/Viewport'
+import {
+  VIEWER_OPTIONS,
+  tiledImageSource,
+  MICRONS_PER_METER,
+  DEMO_MPP,
+} from '../const'
+import { useCallback, useRef, useState } from 'react'
+import CanvasOverlay from '../components/CanvasOverlay'
+
+let timer: ReturnType<typeof setTimeout>
+
+export default function TestPage() {
+  const osdViewerRef = useRef<OSDViewerRef>(null)
+
+  const [rectSize, setRectSize] = useState<[number, number]>([5000, 5000])
+
+  const handleUpdatedCanvasOverlayRedraw = useCallback<
+    NonNullable<CanvasOverlayProps['onRedraw']>
+  >(
+    (canvas: HTMLCanvasElement, viewer: OpenSeadragon.Viewer) => {
+      const ctx = canvas.getContext('2d')
+
+      if (ctx) {
+        ctx.fillStyle = 'rgba(0,0,0,0.3)'
+        ctx.fillRect(50, 50, rectSize[0], rectSize[1])
+      }
+      if (viewer.world && viewer.world.getItemAt(0)) {
+        const imgSize = viewer.world.getItemAt(0).getContentSize()
+        clearTimeout(timer)
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        timer = setTimeout(() => {
+          setRectSize([Math.random() * imgSize.x, Math.random() * imgSize.y])
+        }, 5000)
+      }
+    },
+    [rectSize]
+  )
+
+  return (
+    <OSDViewer options={VIEWER_OPTIONS} ref={osdViewerRef}>
+      <Viewport osdViewerRef={osdViewerRef} />
+      <tiledImage {...tiledImageSource} />
+      <scalebar
+        pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
+        xOffset={10}
+        yOffset={30}
+        barThickness={3}
+        color="#443aff"
+        fontColor="#53646d"
+        backgroundColor={'rgba(255,255,255,0.5)'}
+        location={ScalebarLocation.BOTTOM_RIGHT}
+      />
+      <CanvasOverlay redrawFn={handleUpdatedCanvasOverlayRedraw} />
+    </OSDViewer>
+  )
+}

--- a/apps/viewer-demo-v2/src/pages/TestCustom.tsx
+++ b/apps/viewer-demo-v2/src/pages/TestCustom.tsx
@@ -1,0 +1,16 @@
+import OSDViewer, { OSDViewerRef } from '@lunit/osd-react-renderer'
+import { VIEWER_OPTIONS } from '../const'
+import { useRef } from 'react'
+
+export default function TestCustom() {
+  const osdViewerRef = useRef<OSDViewerRef>(null)
+
+  return (
+    <OSDViewer options={VIEWER_OPTIONS} ref={osdViewerRef}>
+      <tiledImage
+        url="https://pdl1.api.dev.scope.lunit.io/slides/dzi/metadata?file=mrxs_test/SIZE_TEST_2.mrxs"
+        tileUrlBase="https://pdl1.api.dev.scope.lunit.io/slides/images/dzi/mrxs_test/SIZE_TEST_2.mrxs"
+      />
+    </OSDViewer>
+  )
+}

--- a/apps/viewer-demo-v2/src/pages/Webgl.tsx
+++ b/apps/viewer-demo-v2/src/pages/Webgl.tsx
@@ -1,0 +1,43 @@
+import OSDViewer, {
+  OSDViewerRef,
+  ScalebarLocation,
+} from '@lunit/osd-react-renderer'
+import Viewport from '../components/Viewport'
+import {
+  VIEWER_OPTIONS,
+  tiledImageSource,
+  MICRONS_PER_METER,
+  DEMO_MPP,
+} from '../const'
+import useWebGL from '../hooks/useWebGL'
+import { useRef } from 'react'
+
+export default function WebglPage() {
+  const osdViewerRef = useRef<OSDViewerRef>(null)
+
+  const { onWebGLOverlayRedraw } = useWebGL()
+  const webGLOverlayRef = useRef(null)
+
+  return (
+    <OSDViewer
+      options={VIEWER_OPTIONS}
+      ref={osdViewerRef}
+      style={{ width: '100%', height: '100%' }}
+    >
+      <Viewport osdViewerRef={osdViewerRef} />
+
+      <tiledImage {...tiledImageSource} />
+      <scalebar
+        pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
+        xOffset={10}
+        yOffset={30}
+        barThickness={3}
+        color="#443aff"
+        fontColor="#53646d"
+        backgroundColor={'rgba(255,255,255,0.5)'}
+        location={ScalebarLocation.BOTTOM_RIGHT}
+      />
+      <webGLOverlay ref={webGLOverlayRef} onRedraw={onWebGLOverlayRedraw} />
+    </OSDViewer>
+  )
+}

--- a/apps/viewer-demo-v2/src/pages/index.tsx
+++ b/apps/viewer-demo-v2/src/pages/index.tsx
@@ -1,0 +1,102 @@
+import OSDViewer, {
+  CanvasOverlayProps,
+  OSDViewerRef,
+  ScalebarLocation,
+  TooltipOverlayProps,
+} from '@lunit/osd-react-renderer'
+import MouseTracker from '../components/MouseTracker'
+import ZoomController, { ZoomControllerProps } from '../ZoomController'
+import CanvasOverlay from '../components/CanvasOverlay'
+import {
+  VIEWER_OPTIONS,
+  tiledImageSource,
+  MICRONS_PER_METER,
+  DEMO_MPP,
+  DEFAULT_CONTROLLER_MAX_ZOOM,
+  DEFAULT_CONTROLLER_MIN_ZOOM,
+  RADIUS_UM,
+} from '../const'
+import { useCallback, useRef } from 'react'
+import Viewport from '../components/Viewport'
+import OpenSeadragon from 'openseadragon'
+import { useAtom } from 'jotai'
+import { scaleFactorAtom, viewportZoomAtom } from '../App'
+
+const onTooltipOverlayRedraw: NonNullable<TooltipOverlayProps['onRedraw']> = ({
+  tooltipCoord,
+  overlayCanvasEl,
+  viewer,
+}) => {
+  const ctx = overlayCanvasEl.getContext('2d')
+  if (ctx && tooltipCoord) {
+    const radiusPx = RADIUS_UM / DEMO_MPP
+    const sizeRect = new OpenSeadragon.Rect(0, 0, 2, 2)
+    const lineWidth = viewer.viewport.viewportToImageRectangle(
+      viewer.viewport.viewerElementToViewportRectangle(sizeRect)
+    ).width
+    ctx.lineWidth = lineWidth
+    ctx.beginPath()
+    ctx.arc(tooltipCoord.x, tooltipCoord.y, radiusPx, 0, 2 * Math.PI)
+    ctx.closePath()
+    ctx.stroke()
+  }
+}
+
+export default function Home() {
+  const osdViewerRef = useRef<OSDViewerRef>(null)
+
+  const [scaleFactor] = useAtom(scaleFactorAtom)
+  const [viewportZoom, setViewportZoom] = useAtom(viewportZoomAtom)
+
+  const handleControllerZoom = useCallback<
+    NonNullable<ZoomControllerProps['onZoom']>
+  >(
+    zoom => {
+      setViewportZoom(zoom * scaleFactor)
+    },
+    [scaleFactor, setViewportZoom]
+  )
+
+  const onCanvasOverlayRedraw: NonNullable<CanvasOverlayProps['onRedraw']> = (
+    canvas: HTMLCanvasElement
+  ) => {
+    const ctx = canvas.getContext('2d')
+    if (ctx) {
+      ctx.fillStyle = '#000'
+      ctx.fillRect(50, 50, 5000, 5000)
+    }
+  }
+
+  return (
+    <>
+      <OSDViewer
+        options={VIEWER_OPTIONS}
+        ref={osdViewerRef}
+        style={{ width: '100%', height: '100%' }}
+      >
+        <Viewport osdViewerRef={osdViewerRef} />
+        <tiledImage {...tiledImageSource} />
+        <scalebar
+          pixelsPerMeter={MICRONS_PER_METER / DEMO_MPP}
+          xOffset={10}
+          yOffset={30}
+          barThickness={3}
+          color="#443aff"
+          fontColor="#53646d"
+          backgroundColor={'rgba(255,255,255,0.5)'}
+          location={ScalebarLocation.BOTTOM_RIGHT}
+        />
+        s
+        <CanvasOverlay redrawFn={onCanvasOverlayRedraw} />
+        <tooltipOverlay onRedraw={onTooltipOverlayRedraw} />
+        <MouseTracker osdViewerRef={osdViewerRef} />
+      </OSDViewer>
+      <ZoomController
+        zoom={viewportZoom / scaleFactor}
+        maxZoomLevel={DEFAULT_CONTROLLER_MAX_ZOOM}
+        minZoomLevel={DEFAULT_CONTROLLER_MIN_ZOOM}
+        onZoom={handleControllerZoom}
+      />
+    </>
+  )
+}

--- a/apps/viewer-demo-v2/src/pages/index.tsx
+++ b/apps/viewer-demo-v2/src/pages/index.tsx
@@ -17,10 +17,10 @@ import {
   RADIUS_UM,
 } from '../const'
 import { useCallback, useRef } from 'react'
-import Viewport from '../components/Viewport'
 import OpenSeadragon from 'openseadragon'
 import { useAtom } from 'jotai'
 import { scaleFactorAtom, viewportZoomAtom } from '../App'
+import Viewport from '../components/Viewport'
 
 const onTooltipOverlayRedraw: NonNullable<TooltipOverlayProps['onRedraw']> = ({
   tooltipCoord,
@@ -86,7 +86,6 @@ export default function Home() {
           backgroundColor={'rgba(255,255,255,0.5)'}
           location={ScalebarLocation.BOTTOM_RIGHT}
         />
-        s
         <CanvasOverlay redrawFn={onCanvasOverlayRedraw} />
         <tooltipOverlay onRedraw={onTooltipOverlayRedraw} />
         <MouseTracker osdViewerRef={osdViewerRef} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -3257,7 +3257,7 @@
     npmlog "^4.1.2"
     write-file-atomic "^3.0.3"
 
-"@lunit/osd-react-renderer@^1.0.1":
+"@lunit/osd-react-renderer@^1.0.1", "@lunit/osd-react-renderer@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@lunit/osd-react-renderer/-/osd-react-renderer-1.1.0.tgz#ace89fac023dccac9dbc9094d4aaea379feb5786"
   integrity sha512-/Wt1gONslgIDQiYJCsA4haZj/+pIRtXJP70ZAASk4Eg4D3QPm0r3CMw3SCbjmLBVmNO/6gR4V/oMdYf++7oWHQ==
@@ -3928,6 +3928,11 @@
   resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.10.tgz#992865313bb97d80eefa6aab5f2e4f1e10e84e86"
   integrity sha512-kq1vceWANyZLEt/+hbTWSAjLNhhXYgUw6Ywi0KQ9C7pZJP4Qrr0xjSKb3t59e5GwWtk1L6zt5KTxjH4oPk2l/w==
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/hoist-non-react-statics@*":
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -4086,6 +4091,15 @@
   integrity sha512-ELEYRUie2czuJzaZ5+ziIp9Hhw+juEw8b7C11YNA4QdLCVbQ3qLi2l4aq8XnlqM7V31LZX8dxUuFUCrzHm6sqQ==
   dependencies:
     "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router-dom@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
     "@types/react" "*"
     "@types/react-router" "*"
 
@@ -10904,6 +10918,11 @@ jest@^27.0.6:
     import-local "^3.0.2"
     jest-cli "^27.4.7"
 
+jotai@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.5.0.tgz#dcf4fcfe5e9503fa7d0292eb30eaa4225b01dea3"
+  integrity sha512-iPJDFrhNw3KU4o4SSAESeZoW+nM1L/76VULXZWF23qmivBEcbAQjiF5n1W4Hn5dXAol4tmtEYe4HH7d9emEz0Q==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
@@ -14496,6 +14515,13 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
+react-error-boundary@4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.9:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"
@@ -14538,6 +14564,19 @@ react-router-dom@^5.3.0:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-dom@^5.3.4:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-5.3.4.tgz#2ed62ffd88cae6db134445f4a0c0ae8b91d2e5e6"
+  integrity sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    loose-envify "^1.3.1"
+    prop-types "^15.6.2"
+    react-router "5.3.4"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
 react-router@5.3.3:
   version "5.3.3"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.3.3.tgz#8e3841f4089e728cf82a429d92cdcaa5e4a3a288"
@@ -14548,6 +14587,21 @@ react-router@5.3.3:
     hoist-non-react-statics "^3.1.0"
     loose-envify "^1.3.1"
     mini-create-react-context "^0.4.0"
+    path-to-regexp "^1.7.0"
+    prop-types "^15.6.2"
+    react-is "^16.6.0"
+    tiny-invariant "^1.0.2"
+    tiny-warning "^1.0.0"
+
+react-router@5.3.4:
+  version "5.3.4"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.3.4.tgz#8ca252d70fcc37841e31473c7a151cf777887bb5"
+  integrity sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==
+  dependencies:
+    "@babel/runtime" "^7.12.13"
+    history "^4.9.0"
+    hoist-non-react-statics "^3.1.0"
+    loose-envify "^1.3.1"
     path-to-regexp "^1.7.0"
     prop-types "^15.6.2"
     react-is "^16.6.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -14515,13 +14515,6 @@ react-dom@^17.0.2:
     object-assign "^4.1.1"
     scheduler "^0.20.2"
 
-react-error-boundary@4.0.11:
-  version "4.0.11"
-  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
-  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
-  dependencies:
-    "@babel/runtime" "^7.12.5"
-
 react-error-overlay@^6.0.9:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"


### PR DESCRIPTION
## 📝 Description

I thought the `App.tsx` would be more readable and maintainable if split into pages and components. This helps separate some of the logic and state which should make it easier to make changes and add more pages or components in the future.

## ✔️ PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Chore (non-breaking change which does not affect codebase; Build related changes, version modification, etc.)
- [ ] CI related changes
- [ ] Test Case
- [ ] Performance optimization
- [ ] Site/documentation update
- [ ] Other... Please describe:

## 🎯 Current behavior & 🚀 New behavior

As this is mainly a refactor the behaviour between the current and updated state are the same.

This refactor has updated some packages, added a pages & components directory and used [Jotai](https://jotai.org/) for some state which is used in a lot of places to avoid prop drilling.

## 💣 Is this a breaking change?

- [ ] Yes
- [x] No
